### PR TITLE
Add Hermes Tweet plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -75,6 +75,17 @@
       "version": "1.2.0",
       "description": "cmux terminal integration: terminal I/O, topology control, browser automation, markdown viewer, notifications",
       "tags": ["cmux", "terminal", "browser-automation", "terminal-io"]
+    },
+    {
+      "name": "hermes-tweet",
+      "source": {
+        "source": "github",
+        "repo": "Xquik-dev/hermes-tweet",
+        "sha": "341e991dd21e10105caf1456102f36b246f6e86e"
+      },
+      "version": "0.1.6",
+      "description": "Native Hermes Agent X/Twitter plugin for read-first social media workflows and approval-gated actions.",
+      "tags": ["hermes-agent", "twitter", "x", "social-media", "automation"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ Run `/plugin` and check the **Installed** tab.
 
 ---
 
+### [hermes-tweet](https://github.com/Xquik-dev/hermes-tweet)
+
+**Problem:** X/Twitter research and social workflows need a Hermes Agent native plugin with read-first defaults and explicit action gates.
+
+**Solution:** Adds Hermes Agent skills for X/Twitter research, drafting, and approval-gated actions using Hermes-compatible plugin metadata.
+
+`hermes-tweet`
+
+---
+
 ### [toolbox](plugins/toolbox/README.md)
 
 **Problem:** WebFetch gets blocked by bot detection. Session context vanishes between conversations. Secrets end up hardcoded. References drift out of sync.


### PR DESCRIPTION
## Summary
- Add Hermes Tweet to the Claude Code Zero marketplace manifest.
- Document Hermes Tweet in the README plugin list.
- Pin the source to the reviewed Hermes Tweet commit that includes the native Claude plugin manifest.

## Validation
- unset CLAUDECODE && claude plugin validate .
- python3 -m json.tool .claude-plugin/marketplace.json
- git diff --check
- Checked added lines for sensitive or non-native terms.
- Verified the Hermes Tweet GitHub repository link returns HTTP 200.